### PR TITLE
fix the typo

### DIFF
--- a/chap2.html
+++ b/chap2.html
@@ -1182,7 +1182,7 @@ will learn slowly*<span class="marginnote">
   \delta^{l+1}$ has large enough entries to compensate for the
   smallness of $\sigma'(z^l_j)$.  But I'm speaking of the general
   tendency.</span>.-->
-この式は、ニューロンが飽和状態だと$\delta^l_j$は小さくなる傾向がある事を意味します。また、逆に飽和したニューロンを入力に持つ重みの学習は遅い事も意味します*<span class="marginnote">
+この式は、ニューロンが飽和状態だと$\delta^l_j$は小さくなる傾向がある事を意味します。また、さらに飽和状態のニューロンに入力される重みの学習も遅くなることを意味します*。<span class="marginnote">
 *$(w^{l+1})^T \delta^{l+1}$が十分大きく、$\sigma'(z^l_j)$が小さくてもその埋め合わせができるならば、この推論は成り立ちません。ここでは一般的な傾向について述べています。</span>。
 </p>
 <p>

--- a/chap2.html
+++ b/chap2.html
@@ -1159,7 +1159,7 @@ neuron is either low activation ($\approx 0$) or high activation
 <em>saturated</em> and, as a result, the weight has stopped learning (or
 is learning slowly).  Similar remarks hold also for the biases of
 output neuron.-->
-前章の<a href="chap1.html#sigmoid_graph">シグモイド関数のグラフ</a>を思い出すと、$z^L_j$が$0$か$1$に近づくと関数$\sigma$はとても平坦になっていました。
+前章の<a href="chap1.html#sigmoid_graph">シグモイド関数のグラフ</a>を思い出すと、$\sigma(z^L_j)$が$0$か$1$に近づくとき関数$\sigma$はとても平坦になっていました。
 これは$\sigma'(z^L_j) \approx 0$の状態です。
 従って、出力ニューロンの活性が低かったり($\approx 0$)、高かったり($\approx 1$)すると、最終層の学習は遅い事がわかります。
 このような状況を、出力ニューロンは<em>飽和</em>し、重みの学習が終了している（もしくは重みの学習が遅い）と表現するのが一般的です。


### PR DESCRIPTION
原文がシグモイド関数の「出力」が1に近づくとき、という意味合いで書かれていたので、そのように修正しました。
