### PR TITLE
Fix chap4 twoHNN

### DIFF
--- a/js/chap4.js
+++ b/js/chap4.js
@@ -1407,7 +1407,7 @@ function plotSteps(context, values, yMax) {
     var xScale = scale(0, 1, 360.5, 544.5);
     var yScale = scale(0, yMax, 170.5, 14.5);
     // Sort so the values are in order of increasing s
-    values.sort(function(x, y) {return x.s > y.s});
+    values.sort(function(x, y) {return (x.s - y.s)});
     // graph is an assoc. array who elements are the x and y co-ords
     // of the step positions.
     var graph = [];


### PR DESCRIPTION
Google Chromeにおいて、chap4の段差が２つのステップ函数のグラフがどうもおかしいようでしたので修正しました。
修正前:
![image](https://user-images.githubusercontent.com/1760274/56645532-d54b2c80-66b8-11e9-8883-0b036e5d1700.png)

修正後: 
![image](https://user-images.githubusercontent.com/1760274/56646219-1abc2980-66ba-11e9-839f-e4f40d4688d0.png)

